### PR TITLE
Fade category-row edges on phone; keep sale grid even on mobile

### DIFF
--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -456,6 +456,42 @@ button {
   margin-inline-start: 0.35rem;
 }
 
+/* Phones / touch (no hover): you swipe the row with a finger, so the ‹ ›
+   buttons just crowded the chips. Drop them and show a soft gradient fade at
+   whichever edge can still scroll as a subtle "there's more" hint. Desktop
+   keeps the real buttons. RTL: start edge = right, end edge = left. */
+@media (hover: none), (pointer: coarse) {
+  .cat-scroll-btn {
+    display: none !important;
+  }
+  .cat-nav::before,
+  .cat-nav::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1.7rem;
+    z-index: 5;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+  .cat-nav::before {
+    right: 0;
+    background: linear-gradient(to left, var(--paper), transparent);
+  }
+  .cat-nav::after {
+    left: 0;
+    background: linear-gradient(to right, var(--paper), transparent);
+  }
+  .cat-nav.can-start::before {
+    opacity: 1;
+  }
+  .cat-nav.can-end::after {
+    opacity: 1;
+  }
+}
+
 /* dropdown of sub-categories — opens under its chip, clamped to the viewport */
 .cat-submenu {
   position: absolute;
@@ -811,6 +847,12 @@ button {
   }
   .add-btn {
     font-size: 0.72rem;
+  }
+  /* sale shelf is 2-up on phones — drop a lonely orphan so the grid stays
+     even (aesthetics). Only the sale grid: category pages must show every
+     product. :not(:first-child) keeps a sole sale item from vanishing. */
+  .ph-sale-grid > :last-child:nth-child(odd):not(:first-child) {
+    display: none;
   }
 }
 

--- a/Frontend/src/components/Header.tsx
+++ b/Frontend/src/components/Header.tsx
@@ -301,7 +301,13 @@ export const Header = () => {
           </button>
         </div>
 
-        <nav className="cat-nav" aria-label="קטגוריות" ref={navRef}>
+        <nav
+          className={`cat-nav ${canStart ? "can-start" : ""} ${
+            canEnd ? "can-end" : ""
+          }`}
+          aria-label="קטגוריות"
+          ref={navRef}
+        >
           <button
             type="button"
             className={`cat-scroll-btn start ${canStart ? "show" : ""}`}

--- a/Frontend/src/components/HomeContent.tsx
+++ b/Frontend/src/components/HomeContent.tsx
@@ -86,7 +86,37 @@ export const FeaturedRail = ({ items }: { items: Product[] }) => {
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
+
+    // Touch drag must win over the auto-drift. On phones there's no hover, so
+    // the mouse pause below never fires and the per-frame scrollLeft write
+    // fights the swipe (it snaps back). On a finger/pen press, stop the drift
+    // at once; resume a beat after the finger lifts, resyncing pos so the
+    // hand-off is seamless. Mouse is left to the hover pause (desktop).
+    let resumeT = 0;
+    const onDown = (e: PointerEvent) => {
+      if (e.pointerType === "mouse") return;
+      window.clearTimeout(resumeT);
+      paused.current = true;
+    };
+    const onUp = (e: PointerEvent) => {
+      if (e.pointerType === "mouse") return;
+      window.clearTimeout(resumeT);
+      resumeT = window.setTimeout(() => {
+        if (ref.current) pos.current = ref.current.scrollLeft;
+        paused.current = false;
+      }, 1400);
+    };
+    el.addEventListener("pointerdown", onDown, { passive: true });
+    window.addEventListener("pointerup", onUp, { passive: true });
+    window.addEventListener("pointercancel", onUp, { passive: true });
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.clearTimeout(resumeT);
+      el.removeEventListener("pointerdown", onDown);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
   }, []);
 
   const nudge = (dir: number) => {

--- a/Frontend/src/pages/MainHome.tsx
+++ b/Frontend/src/pages/MainHome.tsx
@@ -326,7 +326,7 @@ export default () => {
               <span className="ph-eyebrow">On sale</span>
               <h2>במבצע עכשיו</h2>
             </div>
-            <div className="ph-grid">
+            <div className="ph-grid ph-sale-grid">
               {fresh.map((p) => (
                 <ProductCard key={p.id} product={p} />
               ))}

--- a/Frontend/src/pages/main-home.css
+++ b/Frontend/src/pages/main-home.css
@@ -79,6 +79,12 @@
   .main-home .hero-stage-inner {
     max-width: 100%;
   }
+  /* phones only: trim the dark statement field's height a touch (less vertical
+     padding + tighter inner gap). The desktop slant/width above is untouched. */
+  .main-home .hero-field {
+    padding-block: clamp(1.5rem, 4.5vw, 2.4rem);
+    gap: clamp(0.75rem, 2.2vw, 1.3rem);
+  }
 }
 
 /* ===========================================================================


### PR DESCRIPTION
- Category nav: on touch devices drop the ‹ › scroll buttons (they crowded
  the last chip) and show a soft gradient fade at whichever edge can still
  scroll, as a swipe hint. Desktop keeps the real buttons.
- Sale shelf: on phones (2-up) hide a lonely orphan card so the grid stays
  even, scoped to the sale grid only (category pages still show everything)
  and guarded so a sole sale item never disappears.